### PR TITLE
Fix synthetic_control when no placebos and the treated country doesn't come first in the data

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -213,7 +213,7 @@ synthetic_control.data.frame <- function(data = NULL,
     data %>%
     dplyr::distinct(!!unit) %>%
     dplyr::mutate(placebo = ifelse(!!unit != i_unit,1,0)) %>%
-    dplyr::arrange(!!unit,placebo) %>%
+    dplyr::arrange(placebo, !!unit) %>%
     dplyr::rename(unit_name = !!unit)
 
 

--- a/tests/testthat/test_synthetic_control.R
+++ b/tests/testthat/test_synthetic_control.R
@@ -180,13 +180,69 @@ test_that("Test initialization of a synth pipeline using sythetic_control() work
                       dplyr::filter(time_unit <= 1995))
 })
 
+test_that("synthetic_control works when no placebos and when the treated country doesn't come first in the data", {
 
+  smoking2 <- smoking %>%
+    dplyr::filter(state %in% c("Rhode Island", "Tennessee", "Connecticut", "California",
+                        "Nevada", "Indiana"))
+  no_placebo <- smoking2 %>%
+    synthetic_control(
+      outcome = cigsale,
+      unit = state,
+      time = year,
+      i_unit = "California",
+      i_time = 1988,
+      generate_placebos = FALSE
+    ) %>%
+    generate_predictor(
+      time_window = 1980:1988,
+      ln_income = mean(lnincome, na.rm = T)
+    ) %>%
+    generate_weights(optimization_window = 1970:1988) %>%
+    generate_control()
 
+  with_placebo <- smoking2 %>%
+    synthetic_control(
+      outcome = cigsale,
+      unit = state,
+      time = year,
+      i_unit = "California",
+      i_time = 1988,
+      generate_placebos = TRUE
+    ) %>%
+    generate_predictor(
+      time_window = 1980:1988,
+      ln_income = mean(lnincome, na.rm = T)
+    ) %>%
+    generate_weights(optimization_window = 1970:1988) %>%
+    generate_control()
 
+  expect_identical(
+    with_placebo %>% grab_outcome(),
+    no_placebo %>% grab_outcome()
+  )
+  expect_identical(
+    with_placebo %>% grab_predictors(),
+    no_placebo %>% grab_predictors()
+  )
+  expect_identical(
+    with_placebo %>% grab_unit_weights(),
+    no_placebo %>% grab_unit_weights()
+  )
+  expect_identical(
+    with_placebo %>% grab_predictor_weights(),
+    no_placebo %>% grab_predictor_weights()
+  )
+  expect_identical(
+    with_placebo %>% grab_balance_table(),
+    no_placebo %>% grab_balance_table()
+  )
+  expect_identical(
+    with_placebo %>% grab_synthetic_control(),
+    no_placebo %>% grab_synthetic_control()
+  )
 
+  # grab_significance and grab_loss show the results even for the placebos
+  # so not tested here
 
-
-
-
-
-
+})

--- a/tests/testthat/test_synthetic_control.R
+++ b/tests/testthat/test_synthetic_control.R
@@ -184,7 +184,7 @@ test_that("synthetic_control works when no placebos and when the treated country
 
   smoking2 <- smoking %>%
     dplyr::filter(state %in% c("Rhode Island", "Tennessee", "Connecticut", "California",
-                        "Nevada", "Indiana"))
+                        "Nevada", "Indiana", "Arkansas"))
   no_placebo <- smoking2 %>%
     synthetic_control(
       outcome = cigsale,


### PR DESCRIPTION
This PR closes #20. It fixes a bug that appears when `synthetic_control()` has `generate_placebos = FALSE` and when the treated country doesn't come first in the data (see the example below).

@edunford I didn't see a NEWS file, is there a place where I can add this so that users know that it is fixed in the Github version?

Currently:
``` r
library(tidysynth)

smoking2 <- smoking %>%
  dplyr::filter(state %in% c("Rhode Island", "Tennessee", "Connecticut", "California",
                             "Nevada", "Indiana", "Arkansas"))
smoking2 %>%
  synthetic_control(
    outcome = cigsale,
    unit = state,
    time = year,
    i_unit = "California",
    i_time = 1988,
    generate_placebos = FALSE
  )
#> # A tibble: 2 × 6
#>   .id      .placebo .type    .outcome          .original_data     .meta   
#>   <chr>       <dbl> <chr>    <list>            <list>             <list>  
#> 1 Arkansas        1 treated  <tibble [19 × 2]> <tibble [31 × 7]>  <tibble>
#> 2 Arkansas        1 controls <tibble [19 × 7]> <tibble [186 × 7]> <tibble>
```

<sup>Created on 2022-08-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

New behavior:
``` r
library(tidysynth)

smoking2 <- smoking %>%
  dplyr::filter(state %in% c("Rhode Island", "Tennessee", "Connecticut", "California",
                             "Nevada", "Indiana", "Arkansas"))
smoking2 %>%
  synthetic_control(
    outcome = cigsale,
    unit = state,
    time = year,
    i_unit = "California",
    i_time = 1988,
    generate_placebos = FALSE
  )
#> # A tibble: 2 × 6
#>   .id        .placebo .type    .outcome          .original_data     .meta   
#>   <chr>         <dbl> <chr>    <list>            <list>             <list>  
#> 1 California        0 treated  <tibble [19 × 2]> <tibble [31 × 7]>  <tibble>
#> 2 California        0 controls <tibble [19 × 7]> <tibble [186 × 7]> <tibble>
```

<sup>Created on 2022-08-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
